### PR TITLE
Fix missing f-string prefix in Circuit error message

### DIFF
--- a/quantumflow/circuits.py
+++ b/quantumflow/circuits.py
@@ -105,8 +105,8 @@ class Circuit(Sequence, Operation):
         else:
             if not set(qbs).issubset(qubits):
                 raise ValueError(
-                    f"Incommensurate qubits: Expected {list(qubits)}"
-                    "but received {list(qbs)}"
+                    f"Incommensurate qubits: Expected {list(qubits)} "
+                    f"but received {list(qbs)}"
                 )
 
         super().__init__(qubits=qubits)


### PR DESCRIPTION
## Summary
- Fix missing `f` prefix on second line of error message string
- Add missing space before "but"

## Problem
The error message for incommensurate qubits showed literal `{list(qbs)}` instead of the actual qubit list:
```
ValueError: Incommensurate qubits: Expected [0]but received {list(qbs)}
```

## Fix
Added `f` prefix and space:
```python
raise ValueError(
    f"Incommensurate qubits: Expected {list(qubits)} "
    f"but received {list(qbs)}"
)
```

Now produces:
```
ValueError: Incommensurate qubits: Expected [0] but received [0, 1]
```

## Test plan
- [x] Verified fix manually
- [x] All existing `circuits_test.py` tests pass

Fixes #128